### PR TITLE
Updated Makefile to use CXXFLAGS for macro passing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,6 @@ includes := -I vendor/glfw/include -I $(VULKAN_SDK)/include
 linkFlags = -L lib/$(platform) -lglfw3
 compileFlags := -std=c++17 $(includes)
 
-ifdef MACRO_DEFS
-    macroDefines := -D $(MACRO_DEFS)
-endif
-
 ifeq ($(OS),Windows_NT)
 
 	LIB_EXT = .lib
@@ -105,7 +101,7 @@ $(target): $(objects)
 # Compile objects to the build directory
 $(buildDir)/%.o: src/%.cpp Makefile
 	$(MKDIR) $(call platformpth, $(@D))
-	$(CXX) -MMD -MP -c $(compileFlags) $< -o $@ $(macroDefines)
+	$(CXX) -MMD -MP -c $(compileFlags) $< -o $@ $(CXXFLAGS)
 
 clear: 
 	clear;

--- a/README.md
+++ b/README.md
@@ -119,18 +119,18 @@ $ make ARGS="--somearg"
 ```
 
 ### Specifying Custom Macro Definitions
-You may also want to pass in your own macro definitions for certain configurations (such as setting log levels). You can pass in your definitions using the `MACRO_DEFS` flag:
+You may also want to pass in your own macro definitions for certain configurations (such as setting log levels). You can pass in your definitions using `CXXFLAGS`:
 
 
 #### macOS & Linux
 
 ```console
-$ make MACRO_DEFS=MY_MACRO
+$ make CXXFLAGS=-DMY_MACRO=1
 ```
 
 #### Windows
 ```shell
-> mingw32-make MACRO_DEFS=MY_MACRO
+> mingw32-make CXXFLAGS=-DMY_MACRO=1
 ```
 
 ### Specifying a Non-Default Compiler
@@ -153,9 +153,9 @@ $ make CXX=g++
 It's pretty simple actually:
 
 1. Fork it from [here](https://github.com/CapsCollective/raylib-cpp-starter/fork)
-2. Create your feature branch (git checkout -b cool-new-feature)
-3. Commit your changes (git commit -m "Added some feature")
-4. Push to the branch (git push origin cool-new-feature)
+2. Create your feature branch (`git checkout -b cool-new-feature`)
+3. Commit your changes (`git commit -m "Added some feature"`)
+4. Push to the branch (`git push origin cool-new-feature`)
 5. Create a new pull request for it!
 
 ### Contributors


### PR DESCRIPTION
As the title suggests, I've updated the `Makefile` to use the standard `CXXFLAGS` argument for passing in macro definitions to align with PR https://github.com/CapsCollective/raylib-cpp-starter/pull/13.